### PR TITLE
GH pipeline for API deployments

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,65 @@
+name: Deploy API
+
+on:
+  push:
+    branches: [ master ]
+    paths: 
+      - "api/**"
+      - ".github/workflows/deploy-api.yml"
+
+
+  workflow_dispatch:
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setting env
+        run: echo "GIT_SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+
+      - name: Setting up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setting up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: AWS login
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set default.region ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: ECR docker login
+        run: |
+          aws ecr get-login-password --region ${{ secrets.AWS_DEFAULT_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+
+      - name: Build and push container
+        run: docker build . -f Dockerfile -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/e-commerce-audit-log-api:$GIT_SHA --platform linux/amd64 --push
+        working-directory: api 
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-docker
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setting env
+        run: echo "GIT_SHA=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+
+      - name: Load SSH key
+        run: |
+          mkdir -p ~/.ssh && echo "StrictHostKeyChecking no" >> ~/.ssh/config
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${{ secrets.SSH_KEY }}" 
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV 
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+
+      - name: Running container
+        run: |
+          ssh ${{ secrets.USER }}@${{ secrets.INSTANCE_IP }} '[ -z "$(docker ps | grep api_e_commerce)" ] || docker stop api_e_commerce'
+          ssh -o SendEnv=GIT_SHA ${{ secrets.USER }}@${{ secrets.INSTANCE_IP }} docker run -d --rm --name api_e_commerce -p 80:${{ secrets.PORT }} --env PORT=${{ secrets.PORT }} --env API_VERSION=${{ secrets.API_VERSION }} --env DATABASE_URL=${{ secrets.DATABASE_URL }} --env IOTA_PERMA_NODE=${{ secrets.IOTA_PERMA_NODE }} --env NETWORK=${{ secrets.NETWORK }} --env EXPLORER=${{ secrets.EXPLORER }} --env DATABASE_NAME=${{ secrets.DATABASE_NAME }} --env SERVER_SECRET=${{ secrets.SERVER_SECRET }} --env SERVER_IDENTITY=${{ secrets.SERVER_IDENTITY }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/e-commerce-audit-log-api:$GIT_SHA          


### PR DESCRIPTION
This pipeline accomplishes two things:
1 - Builds the docker image for the API and pushes it to an ECR repo using a shortened github ref as the image tag
2 - Stops the current running API container on the server and runs it with the new image. 

Open to any suggestions for improvements. 