### PR TITLE
289 improve kubernetes api resiliency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ npm-debug.log
 .DS_Store
 logs
 .vscode
-**/server-identity.json

--- a/README.md
+++ b/README.md
@@ -55,36 +55,32 @@ eceaab9343eb   mongo:latest   "docker-entrypoint.s…"   7 seconds ago   Up 7 se
 
 > You can connect to the api via clients like `MongoDB Compass` by using the defined connection url of the database like for instance `mongodb://root:rootpassword@0.0.0.0:27017`!
 
-### 2. Run the API
+### 2. Create root identity and run the API
 
 2.1. Make sure you are in the `/api` folder and use the following commands:
+
 ```
 npm install     # Install dependencies
-npm run keygen  # Generate root identity: output on SERVER_ENTITY file
-npm run start   # Run server
+npm run keygen  # Generate root identity (if it not exists in the database)
 ```
 
-If it was the first time the api is started, no `SERVER_IDENTITY` is defined since it was left blank previously. The api should log a newly generated identity id which needs to be used as server identity as following:
+The `keygen` phase create a root identity for the server and add it to the database.
+If a root identity already exists in the database, the process will give a notice before exit.
+When the root server identity is generated the output is like the following:
 
 ```
 Successfully connected to mongodb
-Create identity...
-==================================================================================================
-== Store this identity in the as ENV var: did:iota:BfGtLdthmzrUdgYptrZgnC4amXZBZ2C2xQMVM7Bb1cZs ==
-==================================================================================================
+Setting root identity please wait...
 Add server id as trusted root...
 Generate key collection...
 Set server identity as verified...
 Setup Done!
-Please store the generated server identity as environment variable.
-Like: SERVER_IDENTITY=did:iota:BfGtLdthmzrUdgYptrZgnC4amXZBZ2C2xQMVM7Bb1cZs
 ```
 
-2.2. Copy the `SERVER_IDENTITY` into the .env file.
-
-2.3. Run the api again using `npm run start`
+2.2. Run the api again using `npm run start`
 
 It should log that the api was started like following:
+
 ```
 Started API Server on port 3000
 Successfully connected to mongodb

--- a/api/.env-right
+++ b/api/.env-right
@@ -2,13 +2,8 @@ PORT=3000
 API_VERSION=v1
 IOTA_PERMA_NODE=https://chrysalis-chronicle.iota.org/api/mainnet/
 IOTA_HORNET_NODE=https://chrysalis-nodes.iota.org:443
-# IOTA_HORNET_NODE=http://192.168.1.4:14265
 NETWORK=main
-# EXPLORER=https://explorer.iota.org/mainnet/transaction
 DATABASE_NAME=integration-service-db
 DATABASE_URL=mongodb://admin:admin@localhost:27017/integration-service-db?authSource=admin&readPreference=primary&appname=MongoDB%20Compass&ssl=false
 SERVER_SECRET=PpKFhPKJY2efTsN9VkB7WNtYUhX9Utaa
 API_KEY=94F5BA49-12B6-4E45-A487-BF91C442276D
-SERVER_IDENTITY_FILE=server-identity.json
-
-# SERVER_IDENTITY=did:iota:Evg7r3ZrT6zGLHBz4UaCj3687E1sfTf9upJZa22MavE2

--- a/api/.env-right
+++ b/api/.env-right
@@ -1,0 +1,14 @@
+PORT=3000
+API_VERSION=v1
+IOTA_PERMA_NODE=https://chrysalis-chronicle.iota.org/api/mainnet/
+IOTA_HORNET_NODE=https://chrysalis-nodes.iota.org:443
+# IOTA_HORNET_NODE=http://192.168.1.4:14265
+NETWORK=main
+# EXPLORER=https://explorer.iota.org/mainnet/transaction
+DATABASE_NAME=integration-service-db
+DATABASE_URL=mongodb://admin:admin@localhost:27017/integration-service-db?authSource=admin&readPreference=primary&appname=MongoDB%20Compass&ssl=false
+SERVER_SECRET=PpKFhPKJY2efTsN9VkB7WNtYUhX9Utaa
+API_KEY=94F5BA49-12B6-4E45-A487-BF91C442276D
+SERVER_IDENTITY_FILE=server-identity.json
+
+# SERVER_IDENTITY=did:iota:Evg7r3ZrT6zGLHBz4UaCj3687E1sfTf9upJZa22MavE2

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "start": "npm-run-all build start-node",
     "keygen": "npm-run-all build start-keygen",
     "build-watch": "tsc --watch ",
-    "serve-nodemon": "nodemon ./dist/index",
+    "serve-nodemon": "nodemon ./dist/index server",
     "serve": "run-p build-watch serve-nodemon",
     "generate-openapi-schemas": "ts-node ./src/tools/open-api-creator/index.ts"
   },

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -1,7 +1,6 @@
 import { Config, IdentityConfig, StreamsConfig } from '../models/config';
 import isEmpty from 'lodash/isEmpty';
 import * as Identity from '@iota/identity-wasm/node';
-import { existsSync, readFileSync } from 'fs';
 
 const StreamsConfig: StreamsConfig = {
 	node: process.env.IOTA_HORNET_NODE,
@@ -25,8 +24,6 @@ export const CONFIG: Config = {
 	apiVersion: process.env.API_VERSION,
 	databaseUrl: process.env.DATABASE_URL,
 	databaseName: process.env.DATABASE_NAME,
-	serverIdentityFile: process.env.SERVER_IDENTITY_FILE,
-	serverIdentityId: process.env.SERVER_IDENTITY,
 	serverSecret: process.env.SERVER_SECRET,
 	hornetNode: process.env.IOTA_HORNET_NODE,
 	permaNode: process.env.IOTA_PERMA_NODE,
@@ -39,7 +36,7 @@ export const CONFIG: Config = {
 
 const assertConfig = (config: Config) => {
 	
-	if (config.serverSecret === '<server-secret>' || config.serverIdentityId === '<server-identity>') {
+	if (config.serverSecret === '<server-secret>') {
 		console.error('please replace the default values!');
 	}
 
@@ -49,7 +46,7 @@ const assertConfig = (config: Config) => {
 
 	// apiKey can be empty if the host decides so
 	// commitHash is set automatically during deployment
-	const optionalEnvVariables = ['apiKey', 'commitHash', 'serverIdentityFile'];
+	const optionalEnvVariables = ['apiKey', 'commitHash'];
 	Object.values(config).map((value, i) => {
 		if (isEmpty(value) && (isNaN(value) || value == null || value === '')) {
 			if (optionalEnvVariables.includes(Object.keys(config)[i])) {
@@ -59,16 +56,6 @@ const assertConfig = (config: Config) => {
 			console.error(`env var is missing or invalid: ${Object.keys(config)[i]}`);
 		}
 	});
-
-	if (config.serverIdentityFile) {
-		if (existsSync(config.serverIdentityFile)) {
-			const rootIdentity = JSON.parse(readFileSync(config.serverIdentityFile).toString());
-			if (!rootIdentity.root) {
-				throw new Error('root field missing in the SERVER_IDENTITY_FILE file');
-			}
-			config.serverIdentityId = rootIdentity.root
-		}
-	}
 
 };
 

--- a/api/src/config/server-identity.json
+++ b/api/src/config/server-identity.json
@@ -1,6 +1,7 @@
 {
     "storeIdentity": true,
     "username": "root-identity",
+    "isServerIdentity": true,
     "claim": {
         "type": "Service",
         "name": "Identity Service"

--- a/api/src/config/server.ts
+++ b/api/src/config/server.ts
@@ -1,0 +1,5 @@
+import { ServerRootConfig } from "../models/config";
+
+export const SERVER_IDENTITY: ServerRootConfig = {
+	serverIdentity: null
+};

--- a/api/src/database/user.ts
+++ b/api/src/database/user.ts
@@ -26,6 +26,11 @@ export const searchUsers = async (userSearch: UserSearch): Promise<UserPersisten
 	return await MongoDbService.getDocuments<UserPersistence>(collectionName, plainQuery, options);
 };
 
+export const getServerIdentity = async (): Promise<UserPersistence | null> => {
+	const query = { isServerIdentity: true };
+	return await MongoDbService.getDocument<UserPersistence>(collectionName, query);
+};
+
 export const getUser = async (identityId: string): Promise<UserPersistence | null> => {
 	const query = { _id: identityId };
 	return await MongoDbService.getDocument<UserPersistence>(collectionName, query);
@@ -118,7 +123,9 @@ export const removeUserVC = async (vc: VerifiableCredentialJson): Promise<UserPe
 	const query = {
 		_id: vc.id
 	};
-	const filteredCredentials = currentVCs.filter((verifiableCredential) => verifiableCredential.proof.signatureValue !== vc.proof.signatureValue);
+	const filteredCredentials = currentVCs.filter(
+		(verifiableCredential) => verifiableCredential.proof.signatureValue !== vc.proof.signatureValue
+	);
 
 	const updateObject = MongoDbService.getPlainObject({
 		verifiableCredentials: filteredCredentials

--- a/api/src/models/config/index.ts
+++ b/api/src/models/config/index.ts
@@ -5,8 +5,6 @@ export interface Config {
 	apiVersion: string;
 	databaseUrl: string;
 	databaseName: string;
-	serverIdentityFile?: string;
-	serverIdentityId: string;
 	identityConfig: IdentityConfig;
 	streamsConfig: StreamsConfig;
 	serverSecret: string;
@@ -15,6 +13,10 @@ export interface Config {
 	permaNode: string;
 	jwtExpiration: string;
 	commitHash: string;
+}
+
+export interface ServerRootConfig {
+	serverIdentity: string;
 }
 
 export interface IdentityConfig {

--- a/api/src/models/config/services.ts
+++ b/api/src/models/config/services.ts
@@ -5,5 +5,4 @@ export interface AuthenticationServiceConfig {
 export interface VerificationServiceConfig {
 	keyCollectionSize: number;
 	serverSecret: string;
-	serverIdentityId: string;
 }

--- a/api/src/models/schemas/user.ts
+++ b/api/src/models/schemas/user.ts
@@ -8,7 +8,8 @@ export const IdentityWithoutIdFields = {
 	verifiableCredentials: Type.Optional(Type.Array(VerifiableCredentialSchema)),
 	role: Type.Optional(Type.String()),
 	claim: Type.Optional(ClaimSchema),
-	isPrivate: Type.Optional(Type.Boolean())
+	isPrivate: Type.Optional(Type.Boolean()),
+	isServerIdentity: Type.Optional(Type.Boolean())
 };
 
 export const IdentitySchema = Type.Object({

--- a/api/src/routers/services.ts
+++ b/api/src/routers/services.ts
@@ -11,7 +11,7 @@ import { UserService } from '../services/user-service';
 import { VerificationService } from '../services/verification-service';
 import { Logger } from '../utils/logger';
 
-const { serverSecret, identityConfig, serverIdentityId, jwtExpiration, streamsConfig } = CONFIG;
+const { serverSecret, identityConfig, jwtExpiration, streamsConfig } = CONFIG;
 
 export const ssiService = SsiService.getInstance(identityConfig, Logger.getInstance());
 export const authorizationService = new AuthorizationService();
@@ -33,7 +33,6 @@ export const verificationService = new VerificationService(
 	ssiService,
 	userService,
 	{
-		serverIdentityId: serverIdentityId,
 		serverSecret,
 		keyCollectionSize: KEY_COLLECTION_SIZE
 	},

--- a/api/src/routers/verification/index.ts
+++ b/api/src/routers/verification/index.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import { CONFIG } from '../../config';
 import {
 	RevokeVerificationBodySchema,
 	TrustedRootBodySchema,
@@ -11,7 +10,7 @@ import { Logger } from '../../utils/logger';
 import { authorizationService, verificationService } from '../services';
 import { apiKeyMiddleware, authMiddleWare, validate } from '../middlewares';
 
-const verificationRoutes = new VerificationRoutes(verificationService, authorizationService, CONFIG, Logger.getInstance());
+const verificationRoutes = new VerificationRoutes(verificationService, authorizationService, Logger.getInstance());
 const {
 	createVerifiableCredential,
 	checkVerifiableCredential,

--- a/api/src/routes/identity/index.test.ts
+++ b/api/src/routes/identity/index.test.ts
@@ -12,6 +12,7 @@ import { StatusCodes } from 'http-status-codes';
 import { LoggerMock } from '../../test/mocks/logger';
 import { IdentityConfigMock } from '../../test/mocks/config';
 import { VerificationService } from '../../services/verification-service';
+import { SERVER_IDENTITY } from '../../config/server';
 
 describe('test user routes', () => {
 	const serverSecret = 'very-secret-secret';
@@ -32,12 +33,12 @@ describe('test user routes', () => {
 		const identityConfig: IdentityConfig = IdentityConfigMock;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService(ssiService as any, serverSecret, LoggerMock);
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id;
 		verificationService = new VerificationService(
 			ssiService,
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock

--- a/api/src/routes/server-info/index.ts
+++ b/api/src/routes/server-info/index.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 import { CONFIG } from "../../config";
 import { SERVER_IDENTITY } from "../../config/server";
 import { ILogger } from "../../utils/logger";
+import * as os from "os";
 
 export class ServerInfoRoutes {
     constructor(
@@ -11,12 +12,14 @@ export class ServerInfoRoutes {
 
     getServerInfo = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
+            const hostname = os.hostname();
             const commitHash = CONFIG.commitHash || 'not defined';
             const identityId = SERVER_IDENTITY.serverIdentity || 'not defined';
             const version = CONFIG.apiVersion || 'not defined';
 
             res.status(StatusCodes.OK).send({
                 commitHash,
+                hostname,
                 identityId,
                 version
             });

--- a/api/src/routes/server-info/index.ts
+++ b/api/src/routes/server-info/index.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import { CONFIG } from "../../config";
+import { SERVER_IDENTITY } from "../../config/server";
 import { ILogger } from "../../utils/logger";
 
 export class ServerInfoRoutes {
@@ -11,7 +12,7 @@ export class ServerInfoRoutes {
     getServerInfo = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const commitHash = CONFIG.commitHash || 'not defined';
-            const identityId = CONFIG.serverIdentityId || 'not defined';
+            const identityId = SERVER_IDENTITY.serverIdentity || 'not defined';
             const version = CONFIG.apiVersion || 'not defined';
 
             res.status(StatusCodes.OK).send({

--- a/api/src/routes/verification/index.ts
+++ b/api/src/routes/verification/index.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { VerifiableCredentialJson } from '../../models/types/identity';
 import { VerificationService } from '../../services/verification-service';
-import { Config } from '../../models/config';
 import { RevokeVerificationBody, TrustedRootBody, VerifyIdentityBody } from '../../models/types/request-response-bodies';
 import { AuthenticatedRequest, AuthorizationCheck, Subject } from '../../models/types/verification';
 import { User, UserRoles } from '../../models/types/user';
@@ -11,12 +10,12 @@ import { AuthorizationService } from '../../services/authorization-service';
 import { VerifiableCredentialPersistence } from '../../models/types/key-collection';
 import { ILogger } from '../../utils/logger';
 import * as _ from 'lodash';
+import { SERVER_IDENTITY } from '../../config/server';
 
 export class VerificationRoutes {
 	constructor(
 		private readonly verificationService: VerificationService,
 		private readonly authorizationService: AuthorizationService,
-		private readonly config: Config,
 		private readonly logger: ILogger
 	) {}
 
@@ -41,7 +40,7 @@ export class VerificationRoutes {
 
 			const vc: VerifiableCredentialJson = await this.verificationService.verifyIdentity(
 				subject,
-				this.config.serverIdentityId,
+				SERVER_IDENTITY.serverIdentity,
 				initiatorVC?.credentialSubject?.id || requestUser.identityId
 			);
 
@@ -77,7 +76,7 @@ export class VerificationRoutes {
 				throw error;
 			}
 
-			await this.verificationService.revokeVerifiableCredential(vcp, this.config.serverIdentityId);
+			await this.verificationService.revokeVerifiableCredential(vcp, SERVER_IDENTITY.serverIdentity);
 
 			res.sendStatus(StatusCodes.OK);
 		} catch (error) {

--- a/api/src/routes/verification/tests/bundled.test.ts
+++ b/api/src/routes/verification/tests/bundled.test.ts
@@ -8,6 +8,7 @@ import { ServerIdentityMock, UserIdentityMock } from '../../../test/mocks/identi
 import { AuthorizationService } from '../../../services/authorization-service';
 import { LoggerMock } from '../../../test/mocks/logger';
 import { IdentityConfigMock } from '../../../test/mocks/config';
+import { SERVER_IDENTITY } from '../../../config/server';
 
 describe('test authentication routes', () => {
 	const serverSecret = 'very-secret-secret';
@@ -18,9 +19,7 @@ describe('test authentication routes', () => {
 		sendMock = jest.fn();
 		sendStatusMock = jest.fn();
 		nextMock = jest.fn();
-		const config: any = {
-			serverIdentityId: ServerIdentityMock.doc.id
-		};
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id;
 		const identityConfig: IdentityConfig = IdentityConfigMock;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService({} as any, '', LoggerMock);
@@ -30,12 +29,11 @@ describe('test authentication routes', () => {
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock
 		);
-		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, config, LoggerMock);
+		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, LoggerMock);
 
 		res = {
 			send: sendMock,

--- a/api/src/routes/verification/tests/check-vc.test.ts
+++ b/api/src/routes/verification/tests/check-vc.test.ts
@@ -10,6 +10,7 @@ import { VerificationRoutes } from '../index';
 import { AuthorizationService } from '../../../services/authorization-service';
 import { LoggerMock } from '../../../test/mocks/logger';
 import { IdentityConfigMock } from '../../../test/mocks/config';
+import { SERVER_IDENTITY } from '../../../config/server';
 
 const vcToCheck = DeviceIdentityMock.userData.verifiableCredentials[0];
 
@@ -22,9 +23,7 @@ describe('test authentication routes', () => {
 		sendMock = jest.fn();
 		sendStatusMock = jest.fn();
 		nextMock = jest.fn();
-		const config: any = {
-			serverIdentityId: ServerIdentityMock.doc.id
-		};
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id;
 		const identityConfig: IdentityConfig = IdentityConfigMock;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService({} as any, '', LoggerMock);
@@ -34,12 +33,11 @@ describe('test authentication routes', () => {
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock
 		);
-		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, config, LoggerMock);
+		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, LoggerMock);
 
 		res = {
 			send: sendMock,

--- a/api/src/routes/verification/tests/revoke-vc.test.ts
+++ b/api/src/routes/verification/tests/revoke-vc.test.ts
@@ -3,7 +3,7 @@ import * as IdentityDocsDb from '../../../database/identity-docs';
 import { SsiService } from '../../../services/ssi-service';
 import { UserService } from '../../../services/user-service';
 import { VerificationService } from '../../../services/verification-service';
-import { Config, IdentityConfig } from '../../../models/config';
+import { IdentityConfig } from '../../../models/config';
 import { StatusCodes } from 'http-status-codes';
 import { VerificationRoutes } from '../index';
 import * as KeyCollectionLinksDB from '../../../database/verifiable-credentials';
@@ -13,6 +13,7 @@ import { AuthorizationService } from '../../../services/authorization-service';
 import { UserType, UserRoles } from '../../../models/types/user';
 import { LoggerMock } from '../../../test/mocks/logger';
 import { ConfigMock } from '../../../test/mocks/config';
+import { SERVER_IDENTITY } from '../../../config/server';
 
 const vcMock = DeviceIdentityMock.userData.verifiableCredentials[0];
 
@@ -26,7 +27,7 @@ describe('test authentication routes', () => {
 		sendMock = jest.fn();
 		sendStatusMock = jest.fn();
 		nextMock = jest.fn();
-		const config: Config = { ...ConfigMock, serverIdentityId: ServerIdentityMock.doc.id };
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id;
 		const identityConfig: IdentityConfig = ConfigMock.identityConfig;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService({} as any, '', LoggerMock);
@@ -36,12 +37,11 @@ describe('test authentication routes', () => {
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock
 		);
-		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, config, LoggerMock);
+		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, LoggerMock);
 
 		res = {
 			send: sendMock,

--- a/api/src/routes/verification/tests/trusted-roots.test.ts
+++ b/api/src/routes/verification/tests/trusted-roots.test.ts
@@ -10,6 +10,7 @@ import { AuthorizationService } from '../../../services/authorization-service';
 import { UserRoles } from '../../../models/types/user';
 import { LoggerMock } from '../../../test/mocks/logger';
 import { IdentityConfigMock } from '../../../test/mocks/config';
+import { SERVER_IDENTITY } from '../../../config/server';
 
 describe('test authentication routes', () => {
 	const serverSecret = 'very-secret-secret';
@@ -20,9 +21,7 @@ describe('test authentication routes', () => {
 		sendMock = jest.fn();
 		sendStatusMock = jest.fn();
 		nextMock = jest.fn();
-		const config: any = {
-			serverIdentityId: ServerIdentityMock.doc.id
-		};
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id;
 		const identityConfig: IdentityConfig = IdentityConfigMock;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService({} as any, '', LoggerMock);
@@ -32,12 +31,11 @@ describe('test authentication routes', () => {
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock
 		);
-		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, config, LoggerMock);
+		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, LoggerMock);
 
 		res = {
 			send: sendMock,

--- a/api/src/routes/verification/tests/verify-user.test.ts
+++ b/api/src/routes/verification/tests/verify-user.test.ts
@@ -14,6 +14,7 @@ import { AuthorizationService } from '../../../services/authorization-service';
 import { UserType, UserRoles } from '../../../models/types/user';
 import { LoggerMock } from '../../../test/mocks/logger';
 import { IdentityConfigMock } from '../../../test/mocks/config';
+import { SERVER_IDENTITY } from '../../../config/server';
 
 describe('test authentication routes', () => {
 	const serverSecret = 'very-secret-secret';
@@ -24,9 +25,7 @@ describe('test authentication routes', () => {
 		sendMock = jest.fn();
 		sendStatusMock = jest.fn();
 		nextMock = jest.fn();
-		const config: any = {
-			serverIdentityId: ServerIdentityMock.doc.id
-		};
+		SERVER_IDENTITY.serverIdentity = ServerIdentityMock.doc.id
 		const identityConfig: IdentityConfig = IdentityConfigMock;
 		ssiService = SsiService.getInstance(identityConfig, LoggerMock);
 		userService = new UserService({} as any, '', LoggerMock);
@@ -36,13 +35,12 @@ describe('test authentication routes', () => {
 			userService,
 			{
 				serverSecret,
-				serverIdentityId: ServerIdentityMock.doc.id,
 				keyCollectionSize: 2
 			},
 			LoggerMock
 		);
 
-		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, config, LoggerMock);
+		verificationRoutes = new VerificationRoutes(verificationService, authorizationService, LoggerMock);
 
 		res = {
 			send: sendMock,

--- a/api/src/services/tests/verification-service.test.ts
+++ b/api/src/services/tests/verification-service.test.ts
@@ -5,6 +5,7 @@ import { VerificationServiceConfig } from '../../models/config/services';
 import { UserService } from '../user-service';
 import { SsiService } from '../ssi-service';
 import { LoggerMock } from '../../test/mocks/logger';
+import { SERVER_IDENTITY } from '../../config/server';
 
 describe('test getKeyCollection', () => {
 	let ssiService: SsiService, userService: UserService, verificationService: VerificationService;
@@ -16,9 +17,9 @@ describe('test getKeyCollection', () => {
 		keys: [{ public: 'public-key', secret: 'secret-key' }],
 		type: ''
 	};
+	SERVER_IDENTITY.serverIdentity = 'did:iota:123'
 	const cfg: VerificationServiceConfig = {
 		serverSecret: 'very-secret-secret',
-		serverIdentityId: 'did:iota:123',
 		keyCollectionSize
 	};
 	beforeEach(() => {
@@ -48,7 +49,7 @@ describe('test getKeyCollection', () => {
 
 		const keyCollection = await verificationService.getKeyCollection(keyCollectionIndex);
 
-		expect(getKeyCollectionSpy).toHaveBeenCalledWith(keyCollectionIndex, cfg.serverIdentityId, cfg.serverSecret);
+		expect(getKeyCollectionSpy).toHaveBeenCalledWith(keyCollectionIndex, SERVER_IDENTITY.serverIdentity, cfg.serverSecret);
 		expect(generateKeyCollectionSpy).toHaveBeenCalledWith(keyCollectionIndex, keyCollectionSize, {});
 		expect(saveKeyCollectionSpy).toHaveBeenCalledWith(expectedKeyCollection, 'did:iota:123', 'very-secret-secret');
 		expect(getIdentitySpy).toHaveBeenCalled();
@@ -74,7 +75,7 @@ describe('test getKeyCollection', () => {
 
 		const keyCollection = await verificationService.getKeyCollection(keyCollectionIndex);
 
-		expect(getKeyCollectionSpy).toHaveBeenCalledWith(keyCollectionIndex, cfg.serverIdentityId, cfg.serverSecret);
+		expect(getKeyCollectionSpy).toHaveBeenCalledWith(keyCollectionIndex, SERVER_IDENTITY.serverIdentity, cfg.serverSecret);
 		expect(generateKeyCollectionSpy).not.toHaveBeenCalled();
 		expect(saveKeyCollectionSpy).not.toHaveBeenCalled();
 		expect(getIdentitySpy).not.toHaveBeenCalled();

--- a/api/src/services/user-service.ts
+++ b/api/src/services/user-service.ts
@@ -116,7 +116,7 @@ export class UserService {
 		if (user == null || isEmpty(user.identityId)) {
 			throw new Error('Error when parsing the body: identityId must be provided!');
 		}
-		const { publicKey, identityId, username, registrationDate, claim, verifiableCredentials, role, isPrivate } = user;
+		const { publicKey, identityId, username, registrationDate, claim, verifiableCredentials, role, isPrivate, isServerIdentity } = user;
 
 		const userPersistence: UserPersistence = {
 			identityId,
@@ -126,7 +126,8 @@ export class UserService {
 			claim,
 			verifiableCredentials,
 			role: role && (role as UserRoles),
-			isPrivate
+			isPrivate,
+			isServerIdentity
 		};
 
 		return userPersistence;

--- a/api/src/services/verification-service.ts
+++ b/api/src/services/verification-service.ts
@@ -19,12 +19,12 @@ import { JsonldGenerator } from '../utils/jsonld';
 import { Subject } from '../models/types/verification';
 import { ILogger } from '../utils/logger';
 import { ILock, Lock } from '../utils/lock';
+import { SERVER_IDENTITY } from '../config/server';
 
 export class VerificationService {
-	private noIssuerFoundErrMessage = (issuerId: string) => `No identiity found for issuerId: ${issuerId}`;
+	private noIssuerFoundErrMessage = (issuerId: string) => `No identity found for issuerId: ${issuerId}`;
 	private readonly serverSecret: string;
 	private readonly keyCollectionSize: number;
-	private readonly serverIdentityId: string;
 	private readonly lock: ILock;
 
 	constructor(
@@ -33,18 +33,17 @@ export class VerificationService {
 		verificationServiceConfig: VerificationServiceConfig,
 		private readonly logger: ILogger
 	) {
-		const { serverSecret, serverIdentityId, keyCollectionSize } = verificationServiceConfig;
+		const { serverSecret, keyCollectionSize } = verificationServiceConfig;
 		this.serverSecret = serverSecret;
 		this.keyCollectionSize = keyCollectionSize;
-		this.serverIdentityId = serverIdentityId;
 		this.lock = Lock.getInstance();
 	}
 
 	async getKeyCollection(keyCollectionIndex: number) {
-		let keyCollection = await KeyCollectionDb.getKeyCollection(keyCollectionIndex, this.serverIdentityId, this.serverSecret);
+		let keyCollection = await KeyCollectionDb.getKeyCollection(keyCollectionIndex, SERVER_IDENTITY.serverIdentity, this.serverSecret);
 		if (!keyCollection) {
-			keyCollection = await this.generateKeyCollection(keyCollectionIndex, this.keyCollectionSize, this.serverIdentityId);
-			const res = await KeyCollectionDb.saveKeyCollection(keyCollection, this.serverIdentityId, this.serverSecret);
+			keyCollection = await this.generateKeyCollection(keyCollectionIndex, this.keyCollectionSize, SERVER_IDENTITY.serverIdentity);
+			const res = await KeyCollectionDb.saveKeyCollection(keyCollection, SERVER_IDENTITY.serverIdentity, this.serverSecret);
 
 			if (!res?.result.n) {
 				throw new Error('could not save keycollection!');
@@ -76,10 +75,10 @@ export class VerificationService {
 					}
 				};
 
-				const currentCredentialIndex = await VerifiableCredentialsDb.getNextCredentialIndex(this.serverIdentityId);
+				const currentCredentialIndex = await VerifiableCredentialsDb.getNextCredentialIndex(SERVER_IDENTITY.serverIdentity);
 				const keyCollectionIndex = this.getKeyCollectionIndex(currentCredentialIndex);
 				const keyCollection = await this.getKeyCollection(keyCollectionIndex);
-				const nextCredentialIndex = await VerifiableCredentialsDb.getNextCredentialIndex(this.serverIdentityId);
+				const nextCredentialIndex = await VerifiableCredentialsDb.getNextCredentialIndex(SERVER_IDENTITY.serverIdentity);
 				const keyIndex = nextCredentialIndex % KEY_COLLECTION_SIZE;
 				const keyCollectionJson: KeyCollectionJson = {
 					type: keyCollection.type,
@@ -106,7 +105,7 @@ export class VerificationService {
 						initiatorId,
 						isRevoked: false
 					},
-					this.serverIdentityId
+					SERVER_IDENTITY.serverIdentity
 				);
 
 				await this.setUserVerified(credential.id, issuerIdentity.doc.id, vc);
@@ -118,7 +117,7 @@ export class VerificationService {
 	}
 
 	async checkVerifiableCredential(vc: VerifiableCredentialJson): Promise<boolean> {
-		const serverIdentity: IdentityJson = await IdentityDocsDb.getIdentity(this.serverIdentityId, this.serverSecret);
+		const serverIdentity: IdentityJson = await IdentityDocsDb.getIdentity(SERVER_IDENTITY.serverIdentity, this.serverSecret);
 		if (!serverIdentity) {
 			throw new Error('no valid server identity to check the credential.');
 		}
@@ -174,7 +173,7 @@ export class VerificationService {
 					return;
 				}
 
-				await VerifiableCredentialsDb.revokeVerifiableCredential(vcp, this.serverIdentityId);
+				await VerifiableCredentialsDb.revokeVerifiableCredential(vcp, SERVER_IDENTITY.serverIdentity);
 				await this.userService.removeUserVC(vcp.vc);
 
 				return res;

--- a/api/src/setup/index.ts
+++ b/api/src/setup/index.ts
@@ -1,4 +1,3 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { addTrustedRootId } from '../database/trusted-roots';
 import { IdentityJsonUpdate, CreateIdentityBody } from '../models/types/identity';
 import { Subject, CredentialTypes } from '../models/types/verification';
@@ -12,6 +11,8 @@ import * as VerifiableCredentialsDb from '../database/verifiable-credentials';
 import { SsiService } from '../services/ssi-service';
 import { KEY_COLLECTION_SIZE } from '../config/identity';
 import { Config } from '../models/config';
+import { getServerIdentity } from '../database/user';
+import { SERVER_IDENTITY } from '../config/server';
 
 const logger = Logger.getInstance();
 
@@ -20,34 +21,25 @@ export class KeyGenerator {
 
 	constructor(config: Config) {
 		this.config = config;
-
 		if (!this.config.serverSecret) {
 			throw Error('A server secret must be defined to work with the API!');
-		}
-
-		if (!this.config.serverIdentityFile) {
-			throw Error('You need to specify a server identity file');
 		}
 	}
 
 	// Ensure that on the db there is the declared root identity
 	static async checkRootIdentity(config: Config): Promise<IdentityJsonUpdate> {
 		logger.log(`Checking root identity...`);
-		let serverIdentityId = null;
-		try {
-			if (config.serverIdentityFile) {
-				serverIdentityId = KeyGenerator.getRootIdentity(config);
-			}
-		} catch (e) {
-			logger.error(e.message);
-		}
-		if (!serverIdentityId) {
-			serverIdentityId = config.serverIdentityId;
-		}
+		
+		const rootServerIdentity = await getServerIdentity();
+	
+		const serverIdentityId = rootServerIdentity?.identityId;
+
 		if (!serverIdentityId) {
 			logger.error('Root identity is missing');
 			return null;
 		}
+
+		SERVER_IDENTITY.serverIdentity = serverIdentityId;
 
 		const ssiService = SsiService.getInstance(config.identityConfig, logger);
 		const userService = new UserService(ssiService, config.serverSecret, logger);
@@ -57,7 +49,6 @@ export class KeyGenerator {
 			userService,
 			{
 				serverSecret: config.serverSecret,
-				serverIdentityId,
 				keyCollectionSize: KEY_COLLECTION_SIZE
 			},
 			logger
@@ -93,7 +84,7 @@ export class KeyGenerator {
 		logger.log('Api is ready to use!');
 	}
 
-	private async getRootIdentityFromId(serverIdentityId: string): Promise<IdentityJsonUpdate> {
+	private async getRootIdentityFromId(): Promise<IdentityJsonUpdate> {
 		// TODO #254 create initial documents and indexes in mongodb if they are missing on first initialization.
 		// key-collection-links->linkedIdentity (unique + partial {"linkedIdentity":{"$exists":true}})
 
@@ -104,46 +95,42 @@ export class KeyGenerator {
 			userService,
 			{
 				serverSecret: this.config.serverSecret,
-				serverIdentityId,
 				keyCollectionSize: KEY_COLLECTION_SIZE
 			},
 			logger
 		);
 
-		return await tmpVerificationService.getIdentityFromDb(serverIdentityId);
-	}
-
-	public static getRootIdentity(config: Config): string {
-		if (!existsSync(config.serverIdentityFile)) {
-			throw new Error('Server identity file is missing');
-		}
-
-		const rootIdentity = JSON.parse(readFileSync(config.serverIdentityFile).toString());
-		if (!rootIdentity.root) {
-			throw new Error('root field missing in the server identity file');
-		}
-
-		return rootIdentity.root;
+		return await tmpVerificationService.getIdentityFromDb(SERVER_IDENTITY.serverIdentity);
 	}
 
 	// Setup root identity
 	async keyGeneration() {
+
 		logger.log(`Setting root identity please wait...`);
 
 		// Check if root identity exists and if it is valid
-		try {
-			const rootIdentity = KeyGenerator.getRootIdentity(this.config);
-			if (rootIdentity) {
-				logger.error('Root identity already exists: verify it, ' + rootIdentity);
-				const serverIdentity = await this.getRootIdentityFromId(rootIdentity);
-				if (serverIdentity && this.verifyIdentity(serverIdentity)) {
-					logger.log('Root identity is already defined and valid: skip key generation');
-					return;
+		logger.log(`Verify if root identity already exists...`);
+		const serverIdentity = await getServerIdentity();
+		const rootIdentity = serverIdentity?.identityId;
+
+		if (rootIdentity) {
+			SERVER_IDENTITY.serverIdentity = rootIdentity;
+			logger.error('Root identity already exists: verify data');
+			const serverIdentity = await this.getRootIdentityFromId();
+			if (serverIdentity) {
+				if (this.verifyIdentity(serverIdentity)) {
+					logger.log('Root identity is already defined and valid');
+					logger.log('No need to create a root identity');
 				}
-				throw Error('Root identity malformed or not valid: ' + rootIdentity);
+				else {
+					logger.error('Root identity malformed or not valid: ' + rootIdentity);
+					logger.error('Database could be tampered');
+				}
 			}
-		} catch (e) {
-			logger.error(e.message);
+			else {
+				logger.error('Error getting data from db');
+			}
+			return;
 		}
 
 		const serverData: CreateIdentityBody = serverIdentityJson;
@@ -152,24 +139,20 @@ export class KeyGenerator {
 		const userService = new UserService(ssiService, this.config.serverSecret, logger);
 		const identity = await userService.createIdentity(serverData);
 
-		logger.log('==================================================================================================');
-		logger.log(`== Store this identity in the as ENV var: ${identity.doc.id} ==`);
-		logger.log('==================================================================================================');
-
+		SERVER_IDENTITY.serverIdentity = identity.doc.id;
+		
 		// re-create the verification service with a valid server identity id
 		const verificationService = new VerificationService(
 			ssiService,
 			userService,
 			{
 				serverSecret: this.config.serverSecret,
-				serverIdentityId: identity.doc.id,
 				keyCollectionSize: KEY_COLLECTION_SIZE
 			},
 			logger
 		);
 
 		const serverUser = await userService.getUser(identity.doc.id);
-		console.log(serverUser);
 
 		if (!serverUser) {
 			throw new Error('server user not found!');
@@ -195,13 +178,6 @@ export class KeyGenerator {
 
 		await verificationService.verifyIdentity(subject, serverUser.identityId, serverUser.identityId);
 
-		writeFileSync(
-			this.config.serverIdentityFile,
-			JSON.stringify({
-				root: serverUser.identityId
-			})
-		);
-
-		logger.log(`Setup Done! Your root identity is: ${serverUser.identityId}`);
+		logger.log(`Setup Done!`);
 	}
 }

--- a/api/src/setup/index.ts
+++ b/api/src/setup/index.ts
@@ -169,6 +169,7 @@ export class KeyGenerator {
 		);
 
 		const serverUser = await userService.getUser(identity.doc.id);
+		console.log(serverUser);
 
 		if (!serverUser) {
 			throw new Error('server user not found!');

--- a/api/src/test/mocks/config.ts
+++ b/api/src/test/mocks/config.ts
@@ -26,7 +26,6 @@ export const ConfigMock: Config = {
 	databaseUrl: '',
 	apiVersion: '0.1',
 	port: 3000,
-	serverIdentityId: 'did:iota:1234',
 	permaNode: '',
 	hornetNode: '',
 	streamsConfig: StreamsConfigMock,

--- a/kubernetes/is-deployment.yaml
+++ b/kubernetes/is-deployment.yaml
@@ -45,44 +45,7 @@ spec:
           echo waiting for MongoDB;
           sleep 2;
           done
-
-      - name: create-root-identity
-        image: iotaledger/integration-services:latest
-        command: ["node", "dist/index.js", "keygen"]
-        env:
-        - name: "SERVER_IDENTITY"
-          value: "/config/server-identity.json"
-        - name: "DATABASE_NAME"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_NAME
-        - name: "NETWORK"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: NETWORK
-        - name: "DATABASE_URL"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_URL
-        - name: "IOTA_HORNET_NODE"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: IOTA_HORNET_NODE
-
-        - name: "SERVER_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: integration-service-api-secrets
-              key: SERVER_SECRET
-
-        volumeMounts:
-        - mountPath: /config
-          name: root-identity
-
+          
       containers:
       - name: integration-service-api
         image: iotaledger/integration-services:latest

--- a/kubernetes/is-deployment.yaml
+++ b/kubernetes/is-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: integration-service-api
 spec:
-  replicas: 1
+  replicas: 5
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -14,122 +14,117 @@ spec:
         app: integration-service-api
     spec:
       initContainers:
-      - name: wait-for-hornet
-        image: busybox:1.28
-        args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          until nslookup $IOTA_HORNET_NODE | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/';
-          do 
-          echo waiting for Hornet;
-          sleep 2;
-          done
-        env:
-        - name: "IOTA_HORNET_NODE"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: IOTA_HORNET_NODE
+        - name: wait-for-hornet
+          image: busybox:1.28
+          args:
+            - /bin/sh
+            - -c
+            - >
+              set -x;
+              until nslookup $IOTA_HORNET_NODE | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/';
+              do 
+              echo waiting for Hornet;
+              sleep 2;
+              done
+          env:
+            - name: "IOTA_HORNET_NODE"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: IOTA_HORNET_NODE
 
-      - name: wait-for-mongo
-        image: busybox:1.28
-        args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          until nslookup "mongodb-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local";
-          do 
-          echo waiting for MongoDB;
-          sleep 2;
-          done
-          
+        - name: wait-for-mongo
+          image: busybox:1.28
+          args:
+            - /bin/sh
+            - -c
+            - >
+              set -x;
+              until nslookup "mongodb-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local";
+              do 
+              echo waiting for MongoDB;
+              sleep 2;
+              done
+
       containers:
-      - name: integration-service-api
-        image: iotaledger/integration-services:latest
-        command: ["node", "dist/index.js", "server"]
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "250m"
-          limits:
-            memory: "250Mi"
-            cpu: "500m"
-        readinessProbe:
-          httpGet:
-            path: /info
-            port: 3000
-        env:
-        - name: "SERVER_IDENTITY"
-          value: "/config/server-identity.json"
-        - name: "PORT"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: PORT
+        - name: integration-service-api
+          image: iotaledger/integration-services:latest
+          imagePullPolicy: IfNotPresent
+          command: ["node", "dist/index.js", "server"]
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "250m"
+            limits:
+              memory: "250Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /info
+              port: 3000
+          env:
+            - name: "SERVER_IDENTITY_FILE"
+              value: "/config/server-identity.json"
+            - name: "PORT"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: PORT
 
-        - name: "API_VERSION"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: API_VERSION
-        - name: "DATABASE_NAME"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_NAME
-        - name: "NETWORK"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: NETWORK
-        - name: "EXPLORER"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: EXPLORER
-        - name: "IOTA_PERMA_NODE"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: IOTA_PERMA_NODE
-        - name: "DATABASE_URL"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_URL
-        - name: "IOTA_HORNET_NODE"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: IOTA_HORNET_NODE
+            - name: "API_VERSION"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: API_VERSION
+            - name: "DATABASE_NAME"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: DATABASE_NAME
+            - name: "NETWORK"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: NETWORK
+            - name: "EXPLORER"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: EXPLORER
+            - name: "IOTA_PERMA_NODE"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: IOTA_PERMA_NODE
+            - name: "DATABASE_URL"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: DATABASE_URL
+            - name: "IOTA_HORNET_NODE"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: IOTA_HORNET_NODE
 
-        - name: "SERVER_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: integration-service-api-secrets
-              key: SERVER_SECRET
-        - name: "API_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: integration-service-api-secrets
-              key: API_KEY
-        ports:
-        - protocol: TCP
-          containerPort: 3000
-        volumeMounts:
-        - mountPath: /data/db
-          name: db
-        - mountPath: /config
-          name: root-identity
+            - name: "SERVER_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: integration-service-api-secrets
+                  key: SERVER_SECRET
+            - name: "API_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: integration-service-api-secrets
+                  key: API_KEY
+          ports:
+            - protocol: TCP
+              containerPort: 3000
+          volumeMounts:
+            - mountPath: /config
+              name: root-identity
+
       volumes:
-      - name: db
-        persistentVolumeClaim:
-          claimName: integration-service-pvc
-      - name: root-identity
-        persistentVolumeClaim:
-          claimName: root-identity-pvc
-
-
+        - name: root-identity
+          persistentVolumeClaim:
+            claimName: root-identity-pvc

--- a/kubernetes/is-init-job.yaml
+++ b/kubernetes/is-init-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-key
+spec:
+  template:
+    spec:
+      containers:
+      - name: create-root-identity
+        image: iotaledger/integration-services:latest
+        command: ["node", "dist/index.js", "keygen"]
+        env:
+        - name: "SERVER_IDENTITY_FILE"
+          value: "/config/server-identity.json"
+        - name: "DATABASE_NAME"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_NAME
+        - name: "NETWORK"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: NETWORK
+        - name: "DATABASE_URL"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_URL
+        - name: "IOTA_HORNET_NODE"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: IOTA_HORNET_NODE
+
+        - name: "SERVER_SECRET"
+          valueFrom:
+            secretKeyRef:
+              name: integration-service-api-secrets
+              key: SERVER_SECRET
+
+        volumeMounts:
+        - mountPath: /config
+          name: root-identity
+      volumes:
+      - name: root-identity
+        persistentVolumeClaim:
+          claimName: root-identity-pvc
+      restartPolicy: Never
+  backoffLimit: 4

--- a/kubernetes/is-init-job.yaml
+++ b/kubernetes/is-init-job.yaml
@@ -5,46 +5,66 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: cleanup-identity
+          image: busybox:1.28
+          args:
+            - /bin/sh
+            - -c
+            - >
+              set -x;
+              rm -rf /config/server-identity.json
+          volumeMounts:
+            - mountPath: /config
+              name: root-identity
+
       containers:
-      - name: create-root-identity
-        image: iotaledger/integration-services:latest
-        command: ["node", "dist/index.js", "keygen"]
-        env:
-        - name: "SERVER_IDENTITY_FILE"
-          value: "/config/server-identity.json"
-        - name: "DATABASE_NAME"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_NAME
-        - name: "NETWORK"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: NETWORK
-        - name: "DATABASE_URL"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: DATABASE_URL
-        - name: "IOTA_HORNET_NODE"
-          valueFrom:
-            configMapKeyRef:
-              name: integration-service-api-config 
-              key: IOTA_HORNET_NODE
+        - name: create-root-identity
+          image: iotaledger/integration-services:latest
+          imagePullPolicy: IfNotPresent
+          command: ["node", "dist/index.js", "keygen"]
+          env:
+            - name: "SERVER_IDENTITY_FILE"
+              value: "/config/server-identity.json"
+            - name: "DATABASE_NAME"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: DATABASE_NAME
+            - name: "NETWORK"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: NETWORK
+            - name: "DATABASE_URL"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: DATABASE_URL
+            - name: "IOTA_HORNET_NODE"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: IOTA_HORNET_NODE
+            - name: "IOTA_PERMA_NODE"
+              valueFrom:
+                configMapKeyRef:
+                  name: integration-service-api-config
+                  key: IOTA_PERMA_NODE
 
-        - name: "SERVER_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: integration-service-api-secrets
-              key: SERVER_SECRET
+            - name: "SERVER_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: integration-service-api-secrets
+                  key: SERVER_SECRET
 
-        volumeMounts:
-        - mountPath: /config
-          name: root-identity
+          volumeMounts:
+            - mountPath: /config
+              name: root-identity
+
       volumes:
-      - name: root-identity
-        persistentVolumeClaim:
-          claimName: root-identity-pvc
-      restartPolicy: Never
+        - name: root-identity
+          persistentVolumeClaim:
+            claimName: root-identity-pvc
+      restartPolicy: OnFailure
   backoffLimit: 4

--- a/kubernetes/is-pvc.yaml
+++ b/kubernetes/is-pvc.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: integration-service-pvc
-spec:
-  resources:
-    requests:
-      storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
----
+--- # ---
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: integration-service-pvc
+# spec:
+#   resources:
+#     requests:
+#       storage: 1Gi
+#   accessModes:
+#     - ReadWriteOnce
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -16,6 +16,6 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 1Mi
+      storage: 10Mi
   accessModes:
     - ReadWriteOnce

--- a/kubernetes/trash/is-config.yaml
+++ b/kubernetes/trash/is-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: integration-service-api-config
+data:
+  PORT: "3000"
+  API_VERSION: v1
+  DATABASE_NAME: integration-service-db
+  NETWORK: main
+  EXPLORER: https://explorer.iota.org/mainnet/transaction
+  IOTA_PERMA_NODE: https://chrysalis-chronicle.iota.org/api/mainnet/
+  IOTA_HORNET_NODE: https://chrysalis-nodes.iota.org:443
+  DATABASE_URL: mongodb://username:password@mongodb-service.default.svc.cluster.local:27017/integration-service-db?readPreference=primary&appname=integration-service-api&ssl=false

--- a/kubernetes/trash/is-deployment.yaml
+++ b/kubernetes/trash/is-deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-service-api
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: integration-service-api
+  template:
+    metadata:
+      labels:
+        app: integration-service-api
+    spec:
+      initContainers:
+      - name: wait-for-hornet
+        image: busybox:1.28
+        args:
+        - /bin/sh
+        - -c
+        - >
+          set -x;
+          until nslookup $IOTA_HORNET_NODE | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/';
+          do 
+          echo waiting for Hornet;
+          sleep 2;
+          done
+        env:
+        - name: "IOTA_HORNET_NODE"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: IOTA_HORNET_NODE
+
+      - name: wait-for-mongo
+        image: busybox:1.28
+        args:
+        - /bin/sh
+        - -c
+        - >
+          set -x;
+          until nslookup "mongodb-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local";
+          do 
+          echo waiting for MongoDB;
+          sleep 2;
+          done
+          
+      containers:
+      - name: integration-service-api
+        image: iotaledger/integration-services:latest
+        command: ["node", "dist/index.js", "server"]
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "250m"
+          limits:
+            memory: "250Mi"
+            cpu: "500m"
+        readinessProbe:
+          httpGet:
+            path: /info
+            port: 3000
+        env:
+        - name: "SERVER_IDENTITY"
+          value: "/config/server-identity.json"
+        - name: "PORT"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: PORT
+
+        - name: "API_VERSION"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: API_VERSION
+        - name: "DATABASE_NAME"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_NAME
+        - name: "NETWORK"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: NETWORK
+        - name: "EXPLORER"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: EXPLORER
+        - name: "IOTA_PERMA_NODE"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: IOTA_PERMA_NODE
+        - name: "DATABASE_URL"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_URL
+        - name: "IOTA_HORNET_NODE"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: IOTA_HORNET_NODE
+
+        - name: "SERVER_SECRET"
+          valueFrom:
+            secretKeyRef:
+              name: integration-service-api-secrets
+              key: SERVER_SECRET
+        - name: "API_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: integration-service-api-secrets
+              key: API_KEY
+        ports:
+        - protocol: TCP
+          containerPort: 3000
+        volumeMounts:
+        - mountPath: /data/db
+          name: db
+        - mountPath: /config
+          name: root-identity
+      volumes:
+      - name: db
+        persistentVolumeClaim:
+          claimName: integration-service-pvc
+      - name: root-identity
+        persistentVolumeClaim:
+          claimName: root-identity-pvc
+
+

--- a/kubernetes/trash/is-init-job.yaml
+++ b/kubernetes/trash/is-init-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-key
+spec:
+  template:
+    spec:
+      containers:
+      - name: create-root-identity
+        image: iotaledger/integration-services:latest
+        command: ["node", "dist/index.js", "keygen"]
+        env:
+        - name: "SERVER_IDENTITY_FILE"
+          value: "/config/server-identity.json"
+        - name: "DATABASE_NAME"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_NAME
+        - name: "NETWORK"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: NETWORK
+        - name: "DATABASE_URL"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: DATABASE_URL
+        - name: "IOTA_HORNET_NODE"
+          valueFrom:
+            configMapKeyRef:
+              name: integration-service-api-config 
+              key: IOTA_HORNET_NODE
+
+        - name: "SERVER_SECRET"
+          valueFrom:
+            secretKeyRef:
+              name: integration-service-api-secrets
+              key: SERVER_SECRET
+
+        volumeMounts:
+        - mountPath: /config
+          name: root-identity
+      volumes:
+      - name: root-identity
+        persistentVolumeClaim:
+          claimName: root-identity-pvc
+      restartPolicy: Never
+  backoffLimit: 4

--- a/kubernetes/trash/is-pvc.yaml
+++ b/kubernetes/trash/is-pvc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: integration-service-pvc
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: root-identity-pvc
+spec:
+  resources:
+    requests:
+      storage: 1Mi
+  accessModes:
+    - ReadWriteOnce

--- a/kubernetes/trash/is-secrets.yaml
+++ b/kubernetes/trash/is-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: integration-service-api-secrets
+type: Opaque
+data:
+  SERVER_SECRET: UHBLRmhQS0pZMmVmVHNOOVZrQjdXTnRZVWhYOVV0YWE=
+  API_KEY: OTRGNUJBNDktMTJCNi00RTQ1LUE0ODctQkY5MUM0NDIyNzZE
+

--- a/kubernetes/trash/is-service.yaml
+++ b/kubernetes/trash/is-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: integration-service-api
+spec:
+  selector:
+    app: integration-service-api
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000  


### PR DESCRIPTION
The solution proposed is the following:

a particular identity in the "users" collection in the database is marked as "isServerIdentity=true".
This identity is the one created with keygen procedure.
During keygen process if this identity is present, the process verify database credential (to assess if database was tampered)
When service started it checks if the root credential is present, if missing the service exits with error
All those choices go in the direction to make service more stateless than scalable. Adopting those changes the service is autonomous to connect to database, and the tangle via hornet and operate without external intervention.

In kubernetes this mechanism allows the services to be restarted up to when the root credential is created, without intervention.