### PR TITLE
Docs - Add test and deploy action

### DIFF
--- a/.github/workflows/deploy-api-dockerhub.yml
+++ b/.github/workflows/deploy-api-dockerhub.yml
@@ -18,6 +18,8 @@ on:
       - "api/**"
       - ".github/workflows/deploy-api-dockerhub.yml"
 
+  workflow_dispatch:
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -45,11 +45,13 @@ jobs:
           npm i
           fi
       - name: Setup Wiki
+        run: |
           npm run setup
           cd local-wiki/iota-wiki
           yarn
           cd ../../
       - name: Build Wiki
+        run: |
           npm test
       - name: Release to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   pull_request:
-    branches: [docs/addTestAndDeployAction]
+    branches: [master]
   push:
     branches: [docs/addTestAndDeployAction]
 

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - 'master'
       - 'develop'
-  pull_request:
-      branches:
-        - 'master'
-        - 'develop'
+      - '298-begin-wiki-skeleton'
 jobs:
   checks:
     if: github.event_name == 'pull_request'
@@ -44,7 +41,7 @@ jobs:
           sed -i "s+baseUrl: '/',+baseUrl: '/integration-services/',+g" docusaurus.config.js
           yarn build
   gh-release:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -1,0 +1,59 @@
+name: deploy
+
+on:
+  pull_request:
+    branches: [docs/addTestAndDeployAction]
+  push:
+    branches: [docs/addTestAndDeployAction]
+
+jobs:
+  checks:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Test Build
+        run: |
+          cd documentation
+          if [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          npm run setup
+          cd local-wiki/iota-wiki
+          yarn
+          cd ../../
+          npm test
+  gh-release:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: |
+          cd documentation
+          if [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+      - name: Setup Wiki
+          npm run setup
+          cd local-wiki/iota-wiki
+          yarn
+          cd ../../
+      - name: Build Wiki
+          npm test
+      - name: Release to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./local-wiki/iota-wiki/build
+

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -18,16 +18,17 @@ jobs:
       - name: Test Build
         run: |
           cd documentation
-          if [ -e package-lock.json ]; then
-          npm ci
-          else
-          npm i
-          fi
+          export config=$(cat EXTERNAL_DOCS_CONFIG)
           npm run setup
-          cd local-wiki/iota-wiki
+          cd ../
+          rsync -av --progress ./ ./documentation/local-wiki/iota-wiki/external/integration-services --exclude .git --exclude node_modules --exclude local-wiki
+          cd documentation/local-wiki/iota-wiki
           yarn
-          cd ../../
-          npm test
+          export replace_string='/\* AUTO GENERATED EXTERNAL DOCS CONFIG \*/'
+          perl -0pe 's#$ENV{replace_string}#$ENV{config}#' docusaurus.config.js > docusaurus.config.js.cpy
+          rm -f docusaurus.config.js && mv docusaurus.config.js.cpy docusaurus.config.js
+          sed -i "s+baseUrl: '/',+baseUrl: '/integration-services/',+g" docusaurus.config.js
+          yarn build
   gh-release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -44,18 +45,23 @@ jobs:
           else
           npm i
           fi
+          pwd
       - name: Setup Wiki
         run: |
+          cd documentation
+          export config=$(cat EXTERNAL_DOCS_CONFIG)
           npm run setup
-          cd local-wiki/iota-wiki
+          cd ../
+          rsync -av --progress ./ ./documentation/local-wiki/iota-wiki/external/integration-services --exclude .git --exclude node_modules --exclude local-wiki
+          cd documentation/local-wiki/iota-wiki
           yarn
-          cd ../../
-      - name: Build Wiki
-        run: |
-          npm test
+          export replace_string='/\* AUTO GENERATED EXTERNAL DOCS CONFIG \*/'
+          perl -0pe 's#$ENV{replace_string}#$ENV{config}#' docusaurus.config.js > docusaurus.config.js.cpy
+          rm -f docusaurus.config.js && mv docusaurus.config.js.cpy docusaurus.config.js
+          sed -i "s+baseUrl: '/',+baseUrl: '/integration-services/',+g" docusaurus.config.js
+          yarn build
       - name: Release to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./local-wiki/iota-wiki/build
-
+          publish_dir: ./documentation/local-wiki/iota-wiki/build

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -1,11 +1,14 @@
 name: deploy
 
 on:
-  pull_request:
-    branches: [master]
   push:
-    branches: [docs/addTestAndDeployAction]
-
+    branches:
+      - 'master'
+      - 'develop'
+  pull_request:
+      branches:
+        - 'master'
+        - 'develop'
 jobs:
   checks:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/test-docs-wiki-build.yml
+++ b/.github/workflows/test-docs-wiki-build.yml
@@ -13,9 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - name: Test Build
+      - name: Install dependencies
+        run: |
+          cd documentation
+          if [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          pwd
+      - name: Setup Wiki
         run: |
           cd documentation
           export config=$(cat EXTERNAL_DOCS_CONFIG)

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -1,5 +1,1 @@
 # Welcome
-testing publishing
-
-<div>
-shouldn't publish

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -1,1 +1,5 @@
 # Welcome
+testing publishing
+
+<div>
+shouldn't publish


### PR DESCRIPTION
# Description

* Added documentation/static/img folder to store images and avoid iota-wiki-cli error
* Added test-docs-wiki-build action

## Type of change

- [x] Documentation Enhancement

# How Has This Been Tested?

Triggering the action multiple times.  The site is currently deployed at https://lucas-tortora.github.io/integration-services/integration-services/welcome . 

 If you want to deploy to your own GH pages you must: 
1) Enable pages by going into your repository's/fork's by going to `Settings > Pages ` and then selecting to publish the branch `gh-pages`.
2) Enable `Actions` for your repository in the `Actions` tab.
3) Add your branch to the push array in `.github/workflows/test-docs-wiki-build.yml` .

The action will trigger testing your current changes if a PR targeting the `master` branch is created. 

# Checklist:

- [x] I have made corresponding changes to the documentation
