### PR TITLE
fix - no readPreference needed in case of standalone MongoDB

### DIFF
--- a/kubernetes/is-config.yaml
+++ b/kubernetes/is-config.yaml
@@ -7,4 +7,4 @@ data:
   DATABASE_NAME: integration-service-db
   IOTA_PERMA_NODE: https://chrysalis-chronicle.iota.org/api/mainnet/
   IOTA_HORNET_NODE: https://chrysalis-nodes.iota.org:443
-  DATABASE_URL: mongodb://username:password@mongodb-service.default.svc.cluster.local:27017/integration-service-db?readPreference=primary&appname=integration-service-api&ssl=false
+  DATABASE_URL: mongodb://username:password@mongodb-service.default.svc.cluster.local:27017/integration-service-db?appname=integration-service-api&ssl=false


### PR DESCRIPTION
readPreference query parameter has to be specified only in case of MongoDB ReplicaSet topology