### PR TITLE
349 fix null channel data values

### DIFF
--- a/api/src/database/channel-data.ts
+++ b/api/src/database/channel-data.ts
@@ -4,6 +4,7 @@ import { ChannelData } from '../models/types/channel-data';
 import { getDateStringFromDate } from '../utils/date';
 import { ChannelLogRequestOptions } from '../models/types/channel-info';
 import { decrypt, encrypt } from '../utils/encryption';
+import * as _ from 'lodash';
 
 const collectionName = CollectionNames.channelData;
 const getIndex = (link: string, id: string) => `${link}-${id}`;
@@ -51,7 +52,7 @@ export const addChannelData = async (channelAddress: string, id: string, channel
 			link: data.link,
 			messageId: data.messageId,
 			log: {
-				...data.log,
+				..._.omitBy(data.log, _.isUndefined),
 				payload: encryptedPayload
 			}
 		};


### PR DESCRIPTION
**Problem was as following:**

If you insert:
`{x:1, y:undefined}`
into the mongodb, it was expected to write `{x:1}` into the database document but mongodb will convert undefined to null and so it will write:
`{x:1, y:null}`

**Solution:**
before writing into the database undefined values will be ommited using lodash.