### PR TITLE
Docs - Fix Dead Links

### DIFF
--- a/documentation/docs/basics/authentication/concept.md
+++ b/documentation/docs/basics/authentication/concept.md
@@ -69,5 +69,5 @@ For all following requests to endpoints protected by authentication use your JWT
 
 We provide examples of this workflow in the following languages:
 
-1. [Node](https://wiki.iota.org/integration-services/authentication/example_node)
-2. [Iota-is-sdk (Node client)](https://wiki.iota.org/integration-services/authentication/example_is_sdk)
+1. [Node](example_node.md)
+2. [Iota-is-sdk (Node client)](example_is_sdk.md)

--- a/documentation/docs/basics/identity.md
+++ b/documentation/docs/basics/identity.md
@@ -11,7 +11,7 @@ keywords:
 IOTA Identity provides a digital identity anchored on the Tangle and verifiable credentials (VC) 
 that are attachable to said identity. For example, a university student could use this to [validate his degree](https://wiki.iota.org/identity.rs/tutorials/validate_university_degree), or it could be applied in combination with [IOTA Streams](streams.md) to validate a patient's prescriptions and medical data as illustrated bellow.
 
-[![Validate patient data](../../static/img/integration-services/use-case-1.png "Validate patient data")](../../static/img/integration-services/use-case-1.png)
+[![Validate patient data](/img/integration-services/use-case-1.png "Validate patient data")
 
 The concepts of decentralized identities will not be explained in depth in this wiki. You can find more information on IOTA Identity in the following resources:
 

--- a/documentation/docs/getting_started/overview.md
+++ b/documentation/docs/getting_started/overview.md
@@ -12,6 +12,6 @@ keywords:
 
 You can install the Integration Services using the following methods: 
 
-* [Using NodeJs](installation/nodejs/)
-* [Using Kubernetes (**recommended to get started**)](installation/docker_compose/)
-* [Using Docker-Compose](installation/docker_compose/)
+* [Using NodeJs](installation/nodejs/local_setup.md)
+* [Using Kubernetes (**recommended to get started**)](installation/kubernetes/local_setup.md)
+* [Using Docker-Compose](installation/docker_compose/docker_compose.md)

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -35,10 +35,10 @@ decentralized identities and credentials.
 
 This documentation has eight sections.
 
-1. [Getting started](getting_started/overview): All the resources you need to get started.
+1. [Getting started](getting_started/overview.md): All the resources you need to get started.
 2. **Services**: An introduction to the main concepts, use cases and API definitions for the [Audit Trail Gateway](services/audit-trail-gateway/introduction.md) and [Self-Sovereign Identity(SSI) Bridge](services/SSI-bridge/introduction.md).
 3. [Examples](examples/introduction): Examples on creating and managing decentralized identities, verifiable
-   credentials, and _channels_.
+   credentials, and channels.
 4. [Basics](basics/identity): Relevant links to guide you in learning the basics about [Identity](https://wiki.iota.org/identity.rs/introduction) and [Streams](https://wiki.iota.org/streams/welcome).
 5. [API Reference](api_reference): Detailed specification of all endpoints.
 6. [Troubleshooting](troubleshooting.md): Instructions on how to resolve any issues you may encounter while using the services.

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -1,5 +1,5 @@
 ---
-image: ../static/img/integration-services/integration_services_welcome.png
+image: /img/integration-services/integration_services_welcome.png
 description: The IOTA Integration Services implement a high-level API for common interactions with decentralized identities and Data Streams.
 keywords:
 - integration services
@@ -11,7 +11,7 @@ keywords:
 ---
 # Welcome
 
-![Integration Services](../static/img/integration-services/integration_services_welcome.png)
+![Integration Services](/img/integration-services/integration_services_welcome.png)
 
 The IOTA Integration Services implement a high-level API for common interactions with decentralized identities and Data
 Streams based on the [IOTA Identity](https://wiki.iota.org/identity.rs/introduction)
@@ -38,7 +38,7 @@ This documentation has eight sections.
 1. [Getting started](getting_started/overview): All the resources you need to get started.
 2. **Services**: An introduction to the main concepts, use cases and API definitions for the [Audit Trail Gateway](services/audit-trail-gateway/introduction.md) and [Self-Sovereign Identity(SSI) Bridge](services/SSI-bridge/introduction.md).
 3. [Examples](examples/introduction): Examples on creating and managing decentralized identities, verifiable
-   credentials, and channels.
+   credentials, and _channels_.
 4. [Basics](basics/identity): Relevant links to guide you in learning the basics about [Identity](https://wiki.iota.org/identity.rs/introduction) and [Streams](https://wiki.iota.org/streams/welcome).
 5. [API Reference](api_reference): Detailed specification of all endpoints.
 6. [Troubleshooting](troubleshooting.md): Instructions on how to resolve any issues you may encounter while using the services.


### PR DESCRIPTION
# Description of change

* Updated links to use full relative urls
* Changed image path to absolute to avoid errors
* Removed link from image to itself as Docusaurus now includes a "gallery" feature

## Type of change

- Documentation Fix

## How the change has been tested

Wiki was built locally.  

## Change checklist

- [x] I have followed the contribution guidelines for this project


