### PR TITLE
 #28 Adjust import paths for is-shared-modules

### DIFF
--- a/api/shared-modules/package.json
+++ b/api/shared-modules/package.json
@@ -1,20 +1,15 @@
 {
   "name": "@iota/is-shared-modules",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Shared modules of the Integration Service.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build-tsc": "tsc --project ./",
     "build-lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "build": "npm-run-all build-tsc build-lint",
     "serve": "tsc --project ./ --watch"
   },
-  "keywords": [
-    "iota",
-    "integration-services",
-    "identity",
-    "stream",
-    "decentralized"
-  ],
   "author": {
     "name": "Dominic Zettl",
     "email": "dominic.zettl@iota.org"
@@ -25,11 +20,23 @@
       "email": "tim.sigl@iota.org"
     }
   ],
+  "homepage": "https://www.iota.org/solutions/secure-digital-infrastructure",
+  "repository": {
+    "url": "github:iotaledger/integration-services",
+    "type": "git"
+  },
   "bugs": {
     "url": "https://github.com/iotaledger/integration-services/issues",
     "email": "dominic.zettl@iota.org"
   },
   "license": "Apache-2.0",
+  "keywords": [
+    "iota",
+    "integration-services",
+    "identity",
+    "stream",
+    "decentralized"
+  ],
   "dependencies": {
     "@iota/identity-wasm": "^0.4.2",
     "@noble/ed25519": "^1.5.2",
@@ -63,6 +70,7 @@
     "typescript": "=4.1.6"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ]
 }

--- a/api/shared-modules/src/index.ts
+++ b/api/shared-modules/src/index.ts
@@ -1,0 +1,7 @@
+export { MongoDbService } from './services/mongodb-service';
+export { createNonce, decrypt, encrypt, getHexEncodedKey, randomSecretKey, signNonce, verifySignedNonce } from './utils/encryption';
+export { Logger } from './utils/logger';
+export { fromBytes, getDateFromString, getDateStringFromDate, toBytes } from './utils/text';
+export * from './models/schemas';
+export * from './models/schemas/request-response-body';
+export * from './models/types';

--- a/api/shared-modules/src/models/schemas/index.ts
+++ b/api/shared-modules/src/models/schemas/index.ts
@@ -1,0 +1,42 @@
+export {
+	ChannelAddressSchema,
+	ChannelInfoSchema,
+	ChannelInfoSearchSchema,
+	ChannelLogRequestOptionsSchema,
+	ChannelType,
+	TopicSchema
+} from './channel-info';
+export {
+	Encoding,
+	IdentityDocumentJsonSchema,
+	IdentityJsonSchema,
+	IdentityKeyPairJsonSchema,
+	VerifiableCredentialSchema,
+	VerifiableCredentialSubjectSchema
+} from './identity';
+export { AccessRights, SubscriptionSchema, SubscriptionType, SubscriptionUpdateSchema } from './subscription';
+export {
+	AggregateOfferSchema,
+	AggregateRatingSchema,
+	BrandSchema,
+	DemandSchema,
+	DeviceControlledProperty,
+	DeviceDirection,
+	DeviceProtocol,
+	DistanceSchema,
+	ItemAvailability,
+	OfferItemConidition,
+	OfferSchema,
+	PostalAddressSchema,
+	ProductEnum,
+	QuantitativeValueSchema,
+	ReviewRatingSchema,
+	ReviewSchema,
+	ServiceChannelSchema,
+	StructuredValueSchema,
+	ThingObject,
+	ThingSchema,
+	schemaDescriptionCreator
+} from './user-types-helper';
+export { DeviceSchema, OrganizationSchema, PersonSchema, ProductSchema, ServiceSchema } from './user-types';
+export { IdentitySchema, IdentityWithoutIdAndCredentialFields, IdentityWithoutIdFields } from './user';

--- a/api/shared-modules/src/models/schemas/request-response-body/index.ts
+++ b/api/shared-modules/src/models/schemas/request-response-body/index.ts
@@ -1,0 +1,28 @@
+export { NonceSchema, ProveOwnershipPostBodySchema, VerifyJwtBodySchema } from './authentication-bodies';
+export {
+	AddChannelLogBodySchema,
+	ChannelDataSchema,
+	ChannelLogSchema,
+	CreateChannelBodySchema,
+	CreateChannelResponseSchema,
+	ReimportBodySchema,
+	ValidateBodySchema,
+	ValidateResponseSchema
+} from './channel-bodies';
+export { CreateIdentityBodySchema, IdentitySearchBodySchema, LatestIdentityDocSchema, UpdateIdentityBodySchema } from './identity-bodies';
+export { ErrorResponseSchema, IdentityIdSchema } from './misc-bodies';
+export {
+	AuthorizeSubscriptionBodySchema,
+	AuthorizeSubscriptionResponseSchema,
+	RequestSubscriptionBodySchema,
+	RequestSubscriptionResponseSchema,
+	RevokeSubscriptionBodySchema
+} from './subscription-bodies';
+export {
+	ClaimSchema,
+	CreateCredentialBodySchema,
+	RevokeVerificationBodySchema,
+	SubjectBodySchema,
+	TrustedRootBodySchema,
+	VerifiableCredentialBodySchema
+} from './verification-bodies';

--- a/api/shared-modules/src/models/types/index.ts
+++ b/api/shared-modules/src/models/types/index.ts
@@ -1,0 +1,56 @@
+export { ChannelData, ChannelLog } from './channel-data';
+export { ChannelInfo, ChannelInfoPersistence, ChannelInfoSearch, ChannelLogRequestOptions, Topic } from './channel-info';
+export { ConcurrencyLock, ConcurrencyLocks } from './concurrency';
+export {
+	CreateIdentityBody,
+	Credential,
+	CredentialSubject,
+	IdentityDocument,
+	IdentityDocumentJson,
+	IdentityInternal,
+	IdentityJson,
+	IdentityKeyPairJson,
+	IdentityKeys,
+	IdentitySearchBody,
+	LatestIdentityJson,
+	VerifiableCredentialJson
+} from './identity';
+export { KeyCollectionJson, KeyCollectionPersistence, SimpleKeyPair, VerifiableCredentialPersistence } from './key-collection';
+export {
+	AddChannelLogBody,
+	AuthorizeSubscriptionBody,
+	AuthorizeSubscriptionResponse,
+	ChannelInfoBody,
+	CreateChannelBody,
+	CreateChannelResponse,
+	CreateCredentialBody,
+	IdentitySchemaBody,
+	Nonce,
+	ProveOwnershipPostBody,
+	ReimportBody,
+	RequestSubscriptionBody,
+	RequestSubscriptionResponse,
+	RevokeSubscriptionBody,
+	RevokeVerificationBody,
+	TrustedRootBody,
+	ValidateBody,
+	ValidateResponse,
+	VerifiableCredentialBody,
+	VerifyJwtBody
+} from './request-response-bodies';
+export { Subscription, SubscriptionUpdate } from './subscription';
+export {
+	Device,
+	IdentityClaim,
+	Organization,
+	Person,
+	Product,
+	Service,
+	User,
+	UserPersistence,
+	UserRoles,
+	UserSearch,
+	UserSearchResponse,
+	UserType
+} from './user';
+export { AuthenticatedRequest, AuthorizationCheck, CredentialTypes, Subject, VerifiableCredentialInternal } from './verification';

--- a/api/shared-modules/tsconfig.json
+++ b/api/shared-modules/tsconfig.json
@@ -1,104 +1,19 @@
 {
 	"include": ["src/**/*"],
-	"exclude": ["example/", "node_modules", "**/*.spec.ts"],
+	"exclude": ["node_modules"],
 	"compilerOptions": {
-	  /* Visit https://aka.ms/tsconfig.json to read more about this file */
-  
-	  /* Projects */
-	  // "incremental": true,                              /* Enable incremental compilation */
-	  // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-	  // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
-	  // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
-	  // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-	  // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-  
-	  /* Language and Environment */
-	  "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-	  // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-	  // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-	  // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-	  // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-	  // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
-	  // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-	  // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
-	  // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
-	  // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-	  // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-  
-	  /* Modules */
-	  "module": "commonjs",                                /* Specify what module code is generated. */
-	  // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-	  // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-	  // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-	  // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-	  // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-	  // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-	  // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-	  // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-	  // "resolveJsonModule": true,                        /* Enable importing .json files */
-	  // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-  
-	  /* JavaScript Support */
-	  // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-	  // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-	  // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-  
-	  /* Emit */
-	  "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-	  "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-	  // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-	  "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-	  // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-	  "outDir": "lib",                                   /* Specify an output folder for all emitted files. */
-	  // "removeComments": true,                           /* Disable emitting comments. */
-	  // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-	  // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-	  // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-	  // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-	  // "sourceRoot": "src/",                                 /* Specify the root path for debuggers to find the reference source code. */
-	  // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-	  // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-	  // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-	  // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-	  // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-	  // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-	  // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-	  // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-	  // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-	  // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-	  // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-  
-	  /* Interop Constraints */
-	  // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-	  // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-	  "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
-	  // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-	  "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-  
-	  /* Type Checking */
-	  "strict": true,                                      /* Enable all strict type-checking options. */
-	  // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-	  // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
-	  // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-	  // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-	  // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-	  // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-	  // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-	  // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-	  // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-	  // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-	  // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-	  // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-	  // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-	  // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-	  // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-	  // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
-	  // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-	  // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-  
-	  /* Completeness */
-	  // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-	  "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+		"target": "es6",
+		"module": "commonjs",
+		"allowJs": false,
+		"moduleResolution": "node",
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "lib",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
 	}
-  }
-  
+}

--- a/clients/client-sdk/package.json
+++ b/clients/client-sdk/package.json
@@ -40,6 +40,13 @@
     "streams",
     "decentralized"
   ],
+  "dependencies": {
+    "@iota/crypto.js": "^1.8.6",
+    "@iota/is-shared-modules": "^0.1.5",
+    "@iota/util.js": "^1.8.6",
+    "@noble/ed25519": "^1.5.0",
+    "axios": "~0.24.0"
+  },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
@@ -50,13 +57,6 @@
     "typedoc": "^0.22.13",
     "typedoc-plugin-markdown": "^3.11.14",
     "typescript": "^4.5.2"
-  },
-  "dependencies": {
-    "@iota/crypto.js": "^1.8.6",
-    "@iota/is-shared-modules": "^0.1.5",
-    "@iota/util.js": "^1.8.6",
-    "@noble/ed25519": "^1.5.0",
-    "axios": "~0.24.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Export all schemas, interfaces, classes and helper directly from index.ts for easy imports
- Made package.json and tsconfig.json equivalent to is-client